### PR TITLE
#22 : Proof of concept of queries caching

### DIFF
--- a/happy-neighbourhood-spring-shell/src/main/java/com/barsifedron/candid/cqrs/happy/shell/SpringbootApplication.java
+++ b/happy-neighbourhood-spring-shell/src/main/java/com/barsifedron/candid/cqrs/happy/shell/SpringbootApplication.java
@@ -2,8 +2,10 @@ package com.barsifedron.candid.cqrs.happy.shell;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.ComponentScan;
 
+@EnableCaching
 @SpringBootApplication
 @ComponentScan(basePackages = {"com.barsifedron", "com.barsifedron.candid.cqrs.springboot", "com.barsifedron.candid.cqrs.happy.domain", "com.barsifedron.candid.cqrs.springboot.cqrs.command", "com.barsifedron.candid.cqrs.happy.query","com.barsifedron.candid.cqrs.happy"})
 public class SpringbootApplication {

--- a/happy-neighbourhood-spring-shell/src/main/java/com/barsifedron/candid/cqrs/happy/shell/utils/cqrs/query/middleware/CacheQueryBusMiddleware.java
+++ b/happy-neighbourhood-spring-shell/src/main/java/com/barsifedron/candid/cqrs/happy/shell/utils/cqrs/query/middleware/CacheQueryBusMiddleware.java
@@ -1,0 +1,35 @@
+package com.barsifedron.candid.cqrs.happy.shell.utils.cqrs.query.middleware;
+
+import com.barsifedron.candid.cqrs.query.Query;
+import com.barsifedron.candid.cqrs.query.QueryBus;
+import com.barsifedron.candid.cqrs.query.QueryBusMiddleware;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+@Component
+@CacheConfig(cacheNames = "queries")
+public class CacheQueryBusMiddleware implements QueryBusMiddleware {
+
+    @Autowired
+    public CacheQueryBusMiddleware() {
+    }
+
+    @Cacheable(value = "queries", key = "#query")
+    @Override
+    public <T> T dispatch(Query<T> query, QueryBus next) {
+        return next.dispatch(query);
+    }
+
+    /**
+     * For some reason, the above @Cacheable annotation is not taken into account by Spring.
+     * This might have to do with a clash between spring proxy and the middleware interface.
+     * Till I figure it out, calling this method from the query bus does the trick.
+     */
+    @Cacheable(value = "queries", key = "#query")
+    public <T> T runInCache(Query<T> query, QueryBus next) {
+        return this.dispatch(query, next);
+    }
+
+}

--- a/happy-neighbourhood-spring-shell/src/main/java/com/barsifedron/candid/cqrs/happy/shell/utils/cqrs/query/middleware/CacheQueryBusMiddleware.java
+++ b/happy-neighbourhood-spring-shell/src/main/java/com/barsifedron/candid/cqrs/happy/shell/utils/cqrs/query/middleware/CacheQueryBusMiddleware.java
@@ -4,12 +4,10 @@ import com.barsifedron.candid.cqrs.query.Query;
 import com.barsifedron.candid.cqrs.query.QueryBus;
 import com.barsifedron.candid.cqrs.query.QueryBusMiddleware;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
 @Component
-@CacheConfig(cacheNames = "queries")
 public class CacheQueryBusMiddleware implements QueryBusMiddleware {
 
     @Autowired


### PR DESCRIPTION

This is a "proof of concept" pull request only.
But if you run the application with `./gradlew clean bootRun` you should see it working.

It shows how one could theoritically use a single middleware to enable spring `@Cacheable` features for all incoming queries.

**WARNING**

- As it is here, there is no time expiration for the cache. This need to be configured at the cache provider level as explained  [here](https://stackoverflow.com/questions/8181768/can-i-set-a-ttl-for-cacheable). I will leave it to you to configure the REDIS.
- Also, I suspect you need to be disciplined and always override `hashCode()` and `equals()` on you Query objects if you want to avoid any colision issues with this. use it at your own risks.

Another way to do it, should you want something more fine grained, would be to use `@Cacheable` directly on your CommandHandlers and QueryHandlers, the same way you would do with a traditional Spring service. The ones on your Command handlers would evict the cache and the ones on your query handlers register the result in the cache.